### PR TITLE
Add LICENSE (MIT) to enable community attribution & reuse

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Okeh Dono Efasa (Fasaclox)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Why this PR

This repo contains valuable HTML/SVG DAX patterns for Power BI visuals but has no `LICENSE` file. Without a license, the GitHub default is "all rights reserved", which prevents the community from:

- Redistributing templates in derivative works (e.g., skill libraries, snippet collections)
- Documenting attribution clearly in downstream usage
- Adapting and sharing improvements back

## What this PR adds

A standard MIT license file with you (Okeh Dono Efasa / Fasaclox) as copyright holder. MIT is:

- The most common open-source license on GitHub (~50% of repos)
- Maximally permissive: anyone can use, modify, distribute, sublicense
- Requires only attribution (copyright notice preserved)
- Compatible with commercial and non-commercial use

## Alternatives

If MIT feels too permissive, consider:
- **Apache-2.0** — similar but adds explicit patent grant
- **CC0-1.0** — public domain (no attribution required)
- **GPL-3.0** — copyleft (derivatives must also be open source)

Happy to revise this PR with any of those if preferred.

## Context for this request

I'm building a Claude Code skill (`pbi-html-visuals`) that documents patterns for the HTML Content (lite) custom visual in Power BI. Your repo is the most comprehensive collection I've found. Without a license I can only reference URLs (no copy), which is suboptimal for offline reference and skill examples.

Thanks for the great work — and feel free to close this PR if you prefer to keep "all rights reserved" status; I respect that decision.